### PR TITLE
Fix types of `Intl` for ponyfill usage

### DIFF
--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -591,19 +591,19 @@ export namespace Intl {
 	}
 }
 
-export const Intl: {
+export const Intl: typeof globalThis.Intl & {
 	DateTimeFormat: {
 		new (
-			locales?: string | string[],
+			locales?: globalThis.Intl.LocalesArgument,
 			options?: globalThis.Intl.DateTimeFormatOptions,
 		): Intl.DateTimeFormat;
 		(
-			locales?: string | string[],
+			locales?: globalThis.Intl.LocalesArgument,
 			options?: globalThis.Intl.DateTimeFormatOptions,
 		): Intl.DateTimeFormat;
 
 		supportedLocalesOf(
-			locales: string | string[],
+			locales: globalThis.Intl.LocalesArgument,
 			options?: globalThis.Intl.DateTimeFormatOptions,
 		): string[];
 	};


### PR DESCRIPTION
This pull request will fix types of `Intl` object and first argument of `Intl.DateTimeFormat`.

```typescript
// errors in current version, no error in this pull request
import { Intl, Temporal } from "temporal-polyfill-lite";
new Intl.RelativeTimeFormat("en");
new Intl.DateTimeFormat(new Intl.Locale("en"));
```