### PR TITLE
Don't add range formatting functions on legacy engines

### DIFF
--- a/src/DateTimeFormat.ts
+++ b/src/DateTimeFormat.ts
@@ -534,7 +534,13 @@ export function DateTimeFormat(locale: unknown, options: unknown) {
 }
 
 const dtfDescriptors = Object.getOwnPropertyDescriptors(OriginalDateTimeFormat);
-dtfDescriptors.prototype.value = DateTimeFormatImpl.prototype;
+const DateTimeFormatImplPrototype = DateTimeFormatImpl.prototype;
+dtfDescriptors.prototype.value = DateTimeFormatImplPrototype;
+for (const property of ["formatRange", "formatRangeToParts"] as const) {
+	if (!OriginalDateTimeFormat.prototype[property]) {
+		delete DateTimeFormatImplPrototype[property];
+	}
+}
 Object.defineProperties(DateTimeFormat, dtfDescriptors);
 DateTimeFormat.prototype.constructor = DateTimeFormat;
 defineStringTag(DateTimeFormat.prototype, "Intl.DateTimeFormat");


### PR DESCRIPTION
After this pull request, developers can properly detect whether the browser supports range formatting functions in `Intl.DateTimeFormat`:

```javascript
if ("formatRange" in dtf) {
  dtf.formatRange(start, end);
}
```