### PR TITLE
Remove extra observable `[[GetOwnProperty]]` call in `Intl.DateTimeFormat` constructor

### DIFF
--- a/src/DateTimeFormat.ts
+++ b/src/DateTimeFormat.ts
@@ -278,29 +278,32 @@ export function createDateTimeFormat(
 	const coercedOriginalOptions: Intl.DateTimeFormatOptions = createNullPrototypeObject();
 	let rawDtf = new OriginalDateTimeFormat(
 		locales as any,
-		new Proxy(Object(options), {
-			get(originalOptions: Record<keyof any, unknown>, property: keyof Intl.DateTimeFormatOptions) {
-				const value = originalOptions[property];
-				if (property === "timeZone") {
-					if (toLocaleStringTimeZone !== undefined) {
-						if (value !== undefined) {
-							throwTypeError(disallowedField("timeZone"));
+		new Proxy(
+			{},
+			{
+				get(_: unknown, property: keyof Intl.DateTimeFormatOptions) {
+					const value = (options as Record<keyof any, unknown>)[property];
+					if (property === "timeZone") {
+						if (toLocaleStringTimeZone !== undefined) {
+							if (value !== undefined) {
+								throwTypeError(disallowedField("timeZone"));
+							}
+							return (coercedOriginalOptions[property] = toLocaleStringTimeZone);
 						}
-						return (coercedOriginalOptions[property] = toLocaleStringTimeZone);
 					}
-				}
-				if (value === undefined) {
-					return value;
-				}
-				// @ts-expect-error
-				return (coercedOriginalOptions[property] =
-					property === "hour12"
-						? toBoolean(value)
-						: property === "fractionalSecondDigits"
-							? toNumber(value)
-							: toString(value));
+					if (value === undefined) {
+						return value;
+					}
+					// @ts-expect-error
+					return (coercedOriginalOptions[property] =
+						property === "hour12"
+							? toBoolean(value)
+							: property === "fractionalSecondDigits"
+								? toNumber(value)
+								: toString(value));
+				},
 			},
-		}),
+		),
 	);
 
 	if (

--- a/tests/expectedFailures/ecma402-bun.txt
+++ b/tests/expectedFailures/ecma402-bun.txt
@@ -34,5 +34,4 @@ intl402/Temporal/ZonedDateTime/timezone-case-insensitive.js
 # output for "+00:00" changed from "GMT" to "UTC" in Bun
 intl402/Temporal/ZonedDateTime/prototype/toLocaleString/offset-time-zones.js
 
-intl402/DateTimeFormat/constructor-options-order.js
 intl402/Temporal/ZonedDateTime/prototype/round/same-date-starts-twice.js

--- a/tests/expectedFailures/ecma402-node.txt
+++ b/tests/expectedFailures/ecma402-node.txt
@@ -28,5 +28,4 @@ intl402/DateTimeFormat/timezone-case-insensitive.js
 intl402/DateTimeFormat/timezone-legacy-non-iana.js
 intl402/DateTimeFormat/timezone-not-canonicalized.js
 
-intl402/DateTimeFormat/constructor-options-order.js
 intl402/Temporal/ZonedDateTime/prototype/round/same-date-starts-twice.js


### PR DESCRIPTION
Currently, `Intl.DateTimeFormat` constructor from the polyfill accesses `[[GetOwnProperty]]` internal slot of the options object. This is not intentional behavior and not spec-compliant.

It is because `Proxy` accesses `[[GetOwnProperty]]` internal slot of the target object after `get` handler is invoked:

https://tc39.es/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-get-p-receiver

In this pull request, we use a dummy empty object as a `Proxy`'s target to avoid redundant access to userland objects. The `Proxy` only responds to `[[Get]]` correctly, but it's OK because the original `Intl.DateTimeFormat` only access `[[Get]]`.