### PR TITLE
Improve error messages

### DIFF
--- a/src/PlainDate.ts
+++ b/src/PlainDate.ts
@@ -59,7 +59,6 @@ import {
 	forbiddenValueOf,
 	invalidDateTime,
 	invalidMethodCall,
-	outOfBoundsDate,
 } from "./internal/errorMessages.ts";
 import { clamp, compare, isWithin, type NumberSign } from "./internal/math.ts";
 import { isObject } from "./internal/object.ts";
@@ -191,7 +190,7 @@ export function regulateIsoDate(
 		return createIsoDateRecord(year, month, clamp(day, 1, isoDaysInMonth(year, month)));
 	}
 	if (!isValidIsoDate(year, month, day)) {
-		throwRangeError(outOfBoundsDate);
+		throwRangeError(invalidDateTime);
 	}
 	return createIsoDateRecord(year, month, day);
 }

--- a/src/internal/abstractOperations.ts
+++ b/src/internal/abstractOperations.ts
@@ -685,7 +685,7 @@ export function parseTemporalDurationString(isoString: string): DurationSlot {
 	isoString = asciiLowerCase(isoString);
 	const result = isoString.match(durationRegExp);
 	if (!result || invalidDurationRegExp.test(isoString)) {
-		throwRangeError(parseError);
+		throwRangeError(parseError(isoString));
 	}
 	assertNotUndefined(result[1]);
 	const fracPart = balanceTime(

--- a/src/internal/calendars/all.ts
+++ b/src/internal/calendars/all.ts
@@ -20,7 +20,7 @@ import {
 	type MonthCode,
 } from "../calendars.ts";
 import { overflowConstrain, overflowReject, type Overflow } from "../enum.ts";
-import { calendarNotSupported, invalidEra, outOfBoundsDate } from "../errorMessages.ts";
+import { calendarNotSupported, invalidDateTime, invalidEra } from "../errorMessages.ts";
 import { clamp, divFloor, isWithin, modFloor } from "../math.ts";
 import { createNullPrototypeObject } from "../object.ts";
 import { asciiLowerCase } from "../string.ts";
@@ -518,7 +518,7 @@ export function calendarMonthDayToIsoReferenceDate(
 			(day === 30 && (monthCode[0] === 2 || isWithin(monthCode[0], 8, 11))))
 	) {
 		if (overflow === overflowReject) {
-			throwRangeError(outOfBoundsDate);
+			throwRangeError(invalidDateTime);
 		}
 		monthCode[1] = false;
 	}
@@ -591,7 +591,7 @@ export function constrainMonthCode(
 	if (calendar === "hebrew") {
 		return monthCode[1] && !isLeapYearHebrew(arithmeticYear)
 			? overflow === overflowReject
-				? throwRangeError(outOfBoundsDate)
+				? throwRangeError(invalidDateTime)
 				: [6, false]
 			: monthCode;
 	}
@@ -602,7 +602,7 @@ export function constrainMonthCode(
 			monthCode,
 		);
 		return monthCode !== constrainedMonthCode && overflow === overflowReject
-			? throwRangeError(outOfBoundsDate)
+			? throwRangeError(invalidDateTime)
 			: constrainedMonthCode;
 	}
 	return monthCode;
@@ -725,7 +725,7 @@ function constrainDay(
 										: daysInMonthIslamicTabular(year, month),
 						);
 	return day !== constrainedDay && overflow === overflowReject
-		? throwRangeError(outOfBoundsDate)
+		? throwRangeError(invalidDateTime)
 		: constrainedDay;
 }
 
@@ -738,7 +738,7 @@ function constrainDayForMonthCode(
 	if (isChineseDangi(calendar) || calendar === "islamic-umalqura" || calendar === "persian") {
 		const constrainedDay = clamp(day, 1, calendar === "persian" && monthCode[0] <= 6 ? 31 : 30);
 		return day !== constrainedDay && overflow === overflowReject
-			? throwRangeError(outOfBoundsDate)
+			? throwRangeError(invalidDateTime)
 			: constrainedDay;
 	}
 	if (calendar === "hebrew") {
@@ -763,7 +763,7 @@ function constrainMonth(
 				(calendar === "hebrew" && isLeapYearHebrew(year)) || isCopticOrEthiopic(calendar) ? 13 : 12,
 			);
 	if (clampedMonth !== month && overflow === overflowReject) {
-		throwRangeError(outOfBoundsDate);
+		throwRangeError(invalidDateTime);
 	}
 	return clampedMonth;
 }

--- a/src/internal/dateTimeParser.ts
+++ b/src/internal/dateTimeParser.ts
@@ -158,18 +158,18 @@ export function parseIsoDateTime(
 						// `calendarWasCritical` is always `false` here
 						calendarWasCritical = !!criticalFlag;
 					} else if (criticalFlag || calendarWasCritical) {
-						throwRangeError(parseError);
+						throwRangeError(parseError(isoString));
 					}
 				} else if (criticalFlag) {
 					// unknown annotation with critical flag
-					throwRangeError(parseError);
+					throwRangeError(parseError(isoString));
 				}
 			}
 		}
 
 		if (matchedGroups["m"]) {
 			if (calendar && asciiLowerCase(calendar) !== "iso8601") {
-				throwRangeError(parseError);
+				throwRangeError(parseError(isoString));
 			}
 		}
 
@@ -196,7 +196,7 @@ export function parseIsoDateTime(
 			$calendar: calendar,
 		};
 	}
-	throwRangeError(parseError);
+	throwRangeError(parseError(isoString));
 }
 
 const annotationValueRegExp = createRegExp(annotationValue);
@@ -216,7 +216,7 @@ export function parseTemporalCalendarString(item: string): string {
 		);
 	} catch {
 		if (!annotationValueRegExp.test(item)) {
-			throwRangeError(parseError);
+			throwRangeError(parseError(item));
 		}
 		return item;
 	}
@@ -228,7 +228,7 @@ const utcOffsetWithSubMinuteRegExp = createRegExp(utcOffsetWithSubMinute);
 export function parseDateTimeUtcOffset(offset: string): number {
 	const result = offset.match(utcOffsetWithSubMinuteRegExp);
 	if (!result) {
-		throwRangeError(parseError);
+		throwRangeError(parseError(offset));
 	}
 	assertNotUndefined(result[1]);
 	assertNotUndefined(result[2]);

--- a/src/internal/ecmascript.ts
+++ b/src/internal/ecmascript.ts
@@ -2,8 +2,8 @@ import { REQUIRED } from "./enum.ts";
 import {
 	invalidField,
 	invalidNumber,
-	invalidOptionsObject,
 	missingField,
+	notObject,
 	notString,
 	toPrimitiveFailed,
 	undefinedArgument,
@@ -88,7 +88,7 @@ export function toPositiveIntegerWithTruncation(arg: unknown): number {
 /** `GetOptionsObject` */
 export function getOptionsObject(options: unknown = createNullPrototypeObject()): object {
 	if (!isObject(options)) {
-		throwTypeError(invalidOptionsObject);
+		throwTypeError(notObject(options));
 	}
 	return options;
 }

--- a/src/internal/errorMessages.ts
+++ b/src/internal/errorMessages.ts
@@ -1,12 +1,11 @@
 import { getNameFromUnit, Unit } from "./unit.ts";
 
-export const calendarNotSupported = (id: string) =>
-	`calendar not supported in this polyfill: ${id}`;
+export const calendarNotSupported = (id: string) => `unsupported calendar: ${id}`;
 
 export const missingField = (fieldName: string) => `missing field: ${fieldName}`;
 export const invalidField = (fieldName: string) => `invalid field: ${fieldName}`;
 export const disallowedField = (fieldName: string) => `disallowed field: ${fieldName}`;
-export const parseError = "parse error";
+export const parseError = (str: string) => `parse error: ${str}`;
 export const invalidDateTime = "invalid date / time";
 export const outOfBoundsDate = "out-of-bounds date";
 export const outOfBoundsDuration = "out-of-bounds duration";
@@ -19,7 +18,6 @@ export const disallowedUnit = (unit: "auto" | Unit) =>
 export const invalidEra = (era: string) => `invalid era: ${era}`;
 export const notString = (value: unknown) => `${value} is not a string`;
 export const invalidNumber = (value: number) => `invalid number: ${value}`;
-export const invalidOptionsObject = "invalid options object";
 export const invalidTimeZone = (id: string) => `invalid time zone: ${id}`;
 export const invalidMethodCall = "invalid method call";
 export const invalidDate = "invalid date";


### PR DESCRIPTION
* include the original string in parse errors
* make error messages consistent (distinguish "out-of-range" and "invalid" date time)