### PR TITLE
Keep the original input in the error message for duration parsing

### DIFF
--- a/src/internal/abstractOperations.test.ts
+++ b/src/internal/abstractOperations.test.ts
@@ -1,5 +1,9 @@
 import { expect, test } from "vitest";
-import { epochDaysToIsoDate, isoDateToEpochDays } from "./abstractOperations.ts";
+import {
+	epochDaysToIsoDate,
+	isoDateToEpochDays,
+	parseTemporalDurationString,
+} from "./abstractOperations.ts";
 
 test("isoDateToEpochDays and extreme dates", () => {
 	expect(isoDateToEpochDays(321970, 0, 1)).toEqual(116877600);
@@ -20,3 +24,10 @@ test("epochDaysToIsoDate", () => {
 		$day: 1,
 	});
 });
+
+test.for(["aaa", "AAA", "P1MT", "p1mt"])(
+	"parseTemporalDurationString and invalid string: %s",
+	(str) => {
+		expect(() => parseTemporalDurationString(str)).toThrow(str);
+	},
+);

--- a/src/internal/abstractOperations.ts
+++ b/src/internal/abstractOperations.ts
@@ -123,7 +123,7 @@ import {
 	roundHalfFloor,
 	roundHalfTrunc,
 } from "./rounding.ts";
-import { asciiLowerCase, toZeroPaddedDecimalString } from "./string.ts";
+import { toZeroPaddedDecimalString } from "./string.ts";
 import { utcEpochMilliseconds } from "./time.ts";
 import {
 	parseTimeZoneIdentifier,
@@ -678,11 +678,10 @@ export function parseTemporalDurationString(isoString: string): DurationSlot {
 	 * * date time separator "T" should be followed by time units
 	 * * at least one of units should be present
 	 */
-	const invalidDurationRegExp = /[pt]$|[.,](\d{1,9})[hms]./;
+	const invalidDurationRegExp = /[pt]$|[.,](\d{1,9})[hms]./i;
 	const durationRegExp =
-		/^([+-]?)p(?:(\d+)y)?(?:(\d+)m)?(?:(\d+)w)?(?:(\d+)d)?(?:t(?:(\d+)(?:[.,](\d{1,9}))?h)?(?:(\d+)(?:[.,](\d{1,9}))?m)?(?:(\d+)(?:[.,](\d{1,9}))?s)?)?$/;
+		/^([+-]?)p(?:(\d+)y)?(?:(\d+)m)?(?:(\d+)w)?(?:(\d+)d)?(?:t(?:(\d+)(?:[.,](\d{1,9}))?h)?(?:(\d+)(?:[.,](\d{1,9}))?m)?(?:(\d+)(?:[.,](\d{1,9}))?s)?)?$/i;
 
-	isoString = asciiLowerCase(isoString);
 	const result = isoString.match(durationRegExp);
 	if (!result || invalidDurationRegExp.test(isoString)) {
 		throwRangeError(parseError(isoString));


### PR DESCRIPTION
```javascript
Temporal.Duration.from('P05DT');
// before: RangeError ("parse error: p05dt")
// after: RangeError ("parse error: P05DT")
```
